### PR TITLE
Fixed backtrace detection and setting libcap-ng capabilities.

### DIFF
--- a/miniupnpd/genconfig.sh
+++ b/miniupnpd/genconfig.sh
@@ -338,7 +338,7 @@ case $OS_NAME in
         # ask the C preprocessor to tell us its list of default include paths
         CC_INC_PATHS=$(${CC} -E -Wp,-v -x c /dev/null 2>&1 | sed -n -e '/^ \// p')
         if [ -n "${CC_INC_PATHS}" ]; then
-    		BACKTRACE_HDR=$(find ${CC_INC_PATHS} -type f -name 'backtrace.h')
+    		BACKTRACE_HDR=$(find ${CC_INC_PATHS} -maxdepth 1 -type f -name 'backtrace.h')
             if [ -n "${BACKTRACE_HDR}" ]; then
                 echo "#define HAS_BACKTRACE 1" >> ${CONFIGFILE}
             fi

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -3124,10 +3124,15 @@ main(int argc, char * argv[])
 #endif /* HAS_PLEDGE */
 
 #ifdef USE_CAPABILITIES
-	capng_clear(CAPNG_SELECT_BOTH);
-	/* don't need CAP_NET_BIND SERVICE, since ports should already be bound */
-	capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED, CAP_NET_BROADCAST, CAP_NET_ADMIN, CAP_NET_RAW, -1);
-	capng_apply(CAPNG_SELECT_BOTH);
+    capng_setpid(getpid());
+    capng_clear(CAPNG_SELECT_BOTH);
+    /* don't need CAP_NET_BIND SERVICE, since ports should already be bound*/
+    if (capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED, CAP_NET_BROADCAST, CAP_NET_ADMIN, CAP_NET_RAW, -1)) {
+        log_error("Unable to update capability set.");
+    }
+    if (capng_apply(CAPNG_SELECT_BOTH)) {
+        log_error("Unable to apply new capability set.");
+    }
 #endif
 
 #endif /* DROP_PRIVILEGES */


### PR DESCRIPTION
I have made the changes (see [issue #405](https://github.com/miniupnp/miniupnp/issues/405)) that will fix `libbacktrace` detection on Gentoo, and will make sure the `pid` of the forked process is set correctly when setting the `libcap-ng` capabilities.